### PR TITLE
fix: 유저 테이블의 기본키를 변경

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,8 +23,8 @@ export class AuthService {
 
   async login(user: User) {
     const payload = {
-      username: user.userId,
-      sub: user.userId,
+      username: user.userName,
+      sub: user.userName,
       time: new Date().getTime(),
     };
     return {

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, username: payload.username };
+    return { username: payload.sub };
   }
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -5,7 +5,7 @@ export class CreateUserDto {
   @Length(7, 15, {
     message: '아이디는 최소 7글자, 최대 15글자까지 입력하셔야 합니다.',
   })
-  userId: string;
+  userName: string;
 
   @IsString()
   @Length(10, 20, {

--- a/src/users/dto/login.dto.ts
+++ b/src/users/dto/login.dto.ts
@@ -3,7 +3,7 @@ import { CreateUserDto } from './create-user.dto';
 
 export class LoginDto extends CreateUserDto {
   @ValidateIf(() => false)
-  override userId: string;
+  override userName: string;
 
   @ValidateIf(() => false)
   override password: string;

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -1,8 +1,11 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User {
-  @Column({ primary: true, nullable: false, length: 15, unique: true })
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: false, length: 15, unique: true })
   userId: string;
 
   @Column({ nullable: false })

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -6,7 +6,7 @@ export class User {
   id: number;
 
   @Column({ nullable: false, length: 15, unique: true })
-  userId: string;
+  userName: string;
 
   @Column({ nullable: false })
   password: string;

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -38,7 +38,7 @@ describe('UsersController', () => {
     it('should create a new user', async () => {
       // Given
       const createUserDto: CreateUserDto = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'Test@1234567',
       };
       const expectedResult = '아이디 생성에 성공했습니다.';
@@ -56,7 +56,7 @@ describe('UsersController', () => {
     it('should handle service errors', async () => {
       // Given
       const createUserDto: CreateUserDto = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'Test@1234567',
       };
       const errorMessage = '이미 같은 이름의 아이디가 있습니다.';
@@ -73,7 +73,7 @@ describe('UsersController', () => {
 
   describe('login', () => {
     const mockLoginDto: LoginDto = {
-      userId: 'testuser123',
+      userName: 'testuser123',
       password: 'Test@1234567',
     };
 
@@ -135,7 +135,7 @@ describe('UsersController', () => {
     it('should validate login input data', async () => {
       // Given
       const invalidLoginDto = {
-        userId: '', // empty userId
+        userName: '', // empty userName
         password: 'Test@1234567',
       };
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -54,7 +54,7 @@ describe('UsersService', () => {
 
   describe('create', () => {
     const mockCreateUserDto = {
-      userId: 'testuser123',
+      userName: 'testuser123',
       password: 'Test@1234567',
     };
 
@@ -69,7 +69,7 @@ describe('UsersService', () => {
       // Then
       expect(result).toBe('아이디 생성에 성공했습니다.');
       expect(repository.findOne).toHaveBeenCalledWith({
-        where: { userId: mockCreateUserDto.userId },
+        where: { userName: mockCreateUserDto.userName },
       });
       expect(repository.save).toHaveBeenCalled();
       // Logger should not have been called for successful creation
@@ -87,11 +87,11 @@ describe('UsersService', () => {
         new ConflictException('이미 같은 이름의 아이디가 있습니다.'),
       );
       expect(repository.findOne).toHaveBeenCalledWith({
-        where: { userId: mockCreateUserDto.userId },
+        where: { userName: mockCreateUserDto.userName },
       });
       // Verify warning was logged
       expect(logger.warn).toHaveBeenCalledWith(
-        `USER CREATE - Attempted to create duplicate user: ${mockCreateUserDto.userId}`,
+        `USER CREATE - Attempted to create duplicate user: ${mockCreateUserDto.userName}`,
       );
     });
 
@@ -108,7 +108,7 @@ describe('UsersService', () => {
       );
       // Verify error was logged
       expect(logger.error).toHaveBeenCalledWith(
-        `USER CREATE - Failed to create user ${mockCreateUserDto.userId}`,
+        `USER CREATE - Failed to create user ${mockCreateUserDto.userName}`,
         expect.any(String),
       );
     });
@@ -134,14 +134,14 @@ describe('UsersService', () => {
 
   describe('login', () => {
     const mockLoginDto = {
-      userId: 'testuser123',
+      userName: 'testuser123',
       password: 'Test@1234567',
     };
 
-    it('should throw UnauthorizedException if userId is empty', async () => {
+    it('should throw UnauthorizedException if userName is empty', async () => {
       // When & Then
       await expect(
-        service.login({ ...mockLoginDto, userId: '' }),
+        service.login({ ...mockLoginDto, userName: '' }),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -161,7 +161,7 @@ describe('UsersService', () => {
         new UnauthorizedException('존재하지 않는 아이디입니다.'),
       );
       expect(repository.findOne).toHaveBeenCalledWith({
-        where: { userId: mockLoginDto.userId },
+        where: { userName: mockLoginDto.userName },
       });
     });
 
@@ -192,7 +192,7 @@ describe('UsersService', () => {
       // Then
       expect(result).toBe(mockToken);
       expect(jwtService.signAsync).toHaveBeenCalledWith({
-        sub: mockLoginDto.userId,
+        sub: mockLoginDto.userName,
         time: expect.any(Number),
       });
     });

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('UsersController (e2e)', () => {
     it('should create a new user successfully', () => {
       // Given
       const newUser = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'Test@1234567',
       };
       mockUsersRepository.findOne.mockResolvedValue(null);
@@ -64,7 +64,7 @@ describe('UsersController (e2e)', () => {
     it('should return 409 when user already exists', () => {
       // Given
       const existingUser = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'Test@1234567',
       };
       mockUsersRepository.findOne.mockResolvedValue(existingUser);
@@ -81,10 +81,10 @@ describe('UsersController (e2e)', () => {
         });
     });
 
-    it('should return 400 when userId is too short', () => {
+    it('should return 400 when userName is too short', () => {
       // Given
       const invalidUser = {
-        userId: 'test', // 7글자 미만
+        userName: 'test', // 7글자 미만
         password: 'Test@1234567',
       };
       mockUsersRepository.findOne.mockResolvedValue(null);
@@ -104,7 +104,7 @@ describe('UsersController (e2e)', () => {
     it('should return 400 when password format is invalid', () => {
       // Given
       const invalidUser = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'invalidpw', // 특수문자, 대문자 없음, 길이 부족
       };
       mockUsersRepository.findOne.mockResolvedValue(null);
@@ -127,12 +127,12 @@ describe('UsersController (e2e)', () => {
     it('should login successfully and return JWT token', () => {
       // Given
       const loginUser = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'Test@1234567',
       };
       const mockToken = 'mock.jwt.token';
       mockUsersRepository.findOne.mockResolvedValue({
-        userId: loginUser.userId,
+        userName: loginUser.userName,
         password: '$2b$10$abcdefghijklmnopqrstuvwxyz', // 암호화된 비밀번호
       });
       jest
@@ -151,7 +151,7 @@ describe('UsersController (e2e)', () => {
     it('should return 401 when user does not exist', () => {
       // Given
       const nonExistentUser = {
-        userId: 'nonexistent',
+        userName: 'nonexistent',
         password: 'Test@1234567',
       };
       mockUsersRepository.findOne.mockResolvedValue(null);
@@ -171,11 +171,11 @@ describe('UsersController (e2e)', () => {
     it('should return 401 when password is incorrect', () => {
       // Given
       const userWithWrongPassword = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: 'WrongPassword@123',
       };
       mockUsersRepository.findOne.mockResolvedValue({
-        userId: userWithWrongPassword.userId,
+        userName: userWithWrongPassword.userName,
         password: '$2b$10$abcdefghijklmnopqrstuvwxyz',
       });
       jest
@@ -194,10 +194,10 @@ describe('UsersController (e2e)', () => {
         });
     });
 
-    it('should return 401 when userId is empty', () => {
+    it('should return 401 when userName is empty', () => {
       // Given
       const invalidUser = {
-        userId: '',
+        userName: '',
         password: 'Test@1234567',
       };
 
@@ -211,7 +211,7 @@ describe('UsersController (e2e)', () => {
     it('should return 401 when password is empty', () => {
       // Given
       const invalidUser = {
-        userId: 'testuser123',
+        userName: 'testuser123',
         password: '',
       };
 


### PR DESCRIPTION
- 정수형 자동 증가 컬럼 `id` 를 primary key 로 삼기로 했습니다.
    - 검색 효율성, 중복 오류 방지, 관계 설정의 효율성을 위해서입니다.
- 기존에 있던 `userId` 컬럼은 이름을 `userName`으로 바꿨습니다.