### PR TITLE
feat: 작성한 가계부를 조회하는 기능

### DIFF
--- a/src/account-book/account-book.controller.spec.ts
+++ b/src/account-book/account-book.controller.spec.ts
@@ -14,6 +14,7 @@ describe('AccountBookController', () => {
     const mockAccountBookService = {
       create: jest.fn(),
       getAccountBook: jest.fn(),
+      search: jest.fn(),
     };
 
     // Mock JwtAuthGuard
@@ -167,6 +168,92 @@ describe('AccountBookController', () => {
       // When & Then
       await expect(controller.getAccountBook(mockIdx)).rejects.toThrow(
         '조회 과정에서 에러가 발생했습니다.',
+      );
+    });
+  });
+
+  describe('search', () => {
+    const mockAccountBooks = [
+      {
+        idx: 1,
+        title: 'Test Account Book 1',
+        paymentType: 'expense',
+        paymentAmount: 10000,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date(),
+        categoryId: 1,
+        paymentMethodId: 1,
+        userId: 1,
+        user: { id: 1, userName: 'testuser' },
+        category: {
+          name: 'Food',
+        },
+        paymentMethod: {
+          name: 'Cash',
+        },
+      },
+      {
+        idx: 2,
+        title: 'Test Account Book 2',
+        paymentType: 'income',
+        paymentAmount: 20000,
+        createdAt: new Date('2024-01-02'),
+        updatedAt: new Date(),
+        categoryId: 2,
+        paymentMethodId: 2,
+        userId: 1,
+        user: { id: 1, userName: 'testuser' },
+        category: {
+          name: 'Salary',
+        },
+        paymentMethod: {
+          name: 'Bank',
+        },
+      },
+    ] as AccountBook[];
+
+    it('should return account books with date filter', async () => {
+      // Given
+      const query = {
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      };
+      jest.spyOn(service, 'search').mockResolvedValue(mockAccountBooks);
+
+      // When
+      const result = await controller.search(query);
+
+      // Then
+      expect(result).toBe(mockAccountBooks);
+      expect(service.search).toHaveBeenCalledWith(query);
+    });
+
+    it('should return all account books when no filter provided', async () => {
+      // Given
+      const query = {};
+      jest.spyOn(service, 'search').mockResolvedValue(mockAccountBooks);
+
+      // When
+      const result = await controller.search(query);
+
+      // Then
+      expect(result).toBe(mockAccountBooks);
+      expect(service.search).toHaveBeenCalledWith(query);
+    });
+
+    it('should handle service errors', async () => {
+      // Given
+      const query = {
+        startDate: '2024-01-01',
+        endDate: '2024-01-31',
+      };
+      jest
+        .spyOn(service, 'search')
+        .mockRejectedValue(new Error('검색 과정에서 에러가 발생했습니다.'));
+
+      // When & Then
+      await expect(controller.search(query)).rejects.toThrow(
+        '검색 과정에서 에러가 발생했습니다.',
       );
     });
   });

--- a/src/account-book/account-book.controller.spec.ts
+++ b/src/account-book/account-book.controller.spec.ts
@@ -13,6 +13,7 @@ describe('AccountBookController', () => {
     // Mock AccountBookService
     const mockAccountBookService = {
       create: jest.fn(),
+      getAccountBook: jest.fn(),
     };
 
     // Mock JwtAuthGuard
@@ -108,6 +109,64 @@ describe('AccountBookController', () => {
       // When & Then
       await expect(controller.create(mockRequest)).rejects.toThrow(
         'Service error',
+      );
+    });
+  });
+
+  describe('getAccountBook', () => {
+    const mockIdx = 1;
+    const mockAccountBook = {
+      idx: mockIdx,
+      title: 'Test Account Book',
+      paymentType: 'expense',
+      paymentAmount: 10000,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      categoryId: 1,
+      paymentMethodId: 1,
+      userId: 1,
+      user: { id: 1, userName: 'testuser' },
+      category: {
+        name: 'Food',
+      },
+      paymentMethod: {
+        name: 'Cash',
+      },
+    } as AccountBook;
+
+    it('should return account book details successfully', async () => {
+      // Given
+      jest.spyOn(service, 'getAccountBook').mockResolvedValue(mockAccountBook);
+
+      // When
+      const result = await controller.getAccountBook(mockIdx);
+
+      // Then
+      expect(result).toBe(mockAccountBook);
+      expect(service.getAccountBook).toHaveBeenCalledWith(mockIdx);
+    });
+
+    it('should return null when account book is not found', async () => {
+      // Given
+      jest.spyOn(service, 'getAccountBook').mockResolvedValue(null);
+
+      // When
+      const result = await controller.getAccountBook(mockIdx);
+
+      // Then
+      expect(result).toBeNull();
+      expect(service.getAccountBook).toHaveBeenCalledWith(mockIdx);
+    });
+
+    it('should handle service errors', async () => {
+      // Given
+      jest
+        .spyOn(service, 'getAccountBook')
+        .mockRejectedValue(new Error('조회 과정에서 에러가 발생했습니다.'));
+
+      // When & Then
+      await expect(controller.getAccountBook(mockIdx)).rejects.toThrow(
+        '조회 과정에서 에러가 발생했습니다.',
       );
     });
   });

--- a/src/account-book/account-book.controller.ts
+++ b/src/account-book/account-book.controller.ts
@@ -1,4 +1,11 @@
-import { Request, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+  Request,
+  Controller,
+  Post,
+  UseGuards,
+  Get,
+  Param,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AccountBookService } from './account-book.service';
 
@@ -12,5 +19,11 @@ export class AccountBookController {
     const user = req.user;
     const createDto = req.body;
     return this.accountBookService.create({ createDto, user });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/:idx')
+  async getAccountBook(@Param('idx') idx: number) {
+    return this.accountBookService.getAccountBook(idx);
   }
 }

--- a/src/account-book/account-book.controller.ts
+++ b/src/account-book/account-book.controller.ts
@@ -5,6 +5,7 @@ import {
   UseGuards,
   Get,
   Param,
+  Query,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AccountBookService } from './account-book.service';
@@ -19,6 +20,11 @@ export class AccountBookController {
     const user = req.user;
     const createDto = req.body;
     return this.accountBookService.create({ createDto, user });
+  }
+
+  @Get('/search')
+  async search(@Query() query) {
+    return this.accountBookService.search(query);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/account-book/account-book.service.ts
+++ b/src/account-book/account-book.service.ts
@@ -41,27 +41,32 @@ export class AccountBookService {
   }
   /**@description 상세 조회 */
   async getAccountBook(idx: number) {
-    const accountBook = await this.accountBookRepository.findOne({
-      where: { idx },
-      select: {
-        idx: true,
-        title: true,
-        paymentType: true,
-        paymentAmount: true,
-        createdAt: true,
-        category: {
-          name: true,
+    try {
+      const accountBook = await this.accountBookRepository.findOne({
+        where: { idx },
+        select: {
+          idx: true,
+          title: true,
+          paymentType: true,
+          paymentAmount: true,
+          createdAt: true,
+          category: {
+            name: true,
+          },
+          paymentMethod: {
+            name: true,
+          },
         },
-        paymentMethod: {
-          name: true,
+        relations: {
+          category: true,
+          paymentMethod: true,
         },
-      },
-      relations: {
-        category: true,
-        paymentMethod: true,
-      },
-    });
+      });
 
-    return accountBook;
+      return accountBook;
+    } catch (error) {
+      this.logger.error('account-book GET idx', error.stack);
+      throw new Error('조회 과정에서 에러가 발생했습니다.');
+    }
   }
 }

--- a/src/account-book/account-book.service.ts
+++ b/src/account-book/account-book.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, Between } from 'typeorm';
 import { AccountBook } from './account-book.entity';
 import { CustomLoggerService } from '../logger/logger.service';
 import { CreateAccountBookDto } from './dto/create-account-book.dto';
+import { SearchAccountBookDto } from './dto/search-account-book.dto';
 
 @Injectable()
 export class AccountBookService {
@@ -67,6 +68,45 @@ export class AccountBookService {
     } catch (error) {
       this.logger.error('account-book GET idx', error.stack);
       throw new Error('조회 과정에서 에러가 발생했습니다.');
+    }
+  }
+
+  /**@description 검색 */
+  async search(searchFilter: SearchAccountBookDto) {
+    try {
+      const whereCondition: any = {};
+      if (searchFilter.startDate && searchFilter.endDate) {
+        whereCondition.createdAt = Between(
+          searchFilter.startDate,
+          searchFilter.endDate,
+        );
+      }
+
+      const accountBook = await this.accountBookRepository.find({
+        where: whereCondition,
+        select: {
+          idx: true,
+          title: true,
+          paymentType: true,
+          paymentAmount: true,
+          createdAt: true,
+          category: {
+            name: true,
+          },
+          paymentMethod: {
+            name: true,
+          },
+        },
+        relations: {
+          category: true,
+          paymentMethod: true,
+        },
+      });
+
+      return accountBook;
+    } catch (error) {
+      this.logger.error('account-book GET search', error.stack);
+      throw new Error('검색 과정에서 에러가 발생했습니다.');
     }
   }
 }

--- a/src/account-book/account-book.service.ts
+++ b/src/account-book/account-book.service.ts
@@ -39,4 +39,29 @@ export class AccountBookService {
       throw new Error('에러가 발생했습니다.');
     }
   }
+  /**@description 상세 조회 */
+  async getAccountBook(idx: number) {
+    const accountBook = await this.accountBookRepository.findOne({
+      where: { idx },
+      select: {
+        idx: true,
+        title: true,
+        paymentType: true,
+        paymentAmount: true,
+        createdAt: true,
+        category: {
+          name: true,
+        },
+        paymentMethod: {
+          name: true,
+        },
+      },
+      relations: {
+        category: true,
+        paymentMethod: true,
+      },
+    });
+
+    return accountBook;
+  }
 }

--- a/src/account-book/dto/search-account-book.dto.ts
+++ b/src/account-book/dto/search-account-book.dto.ts
@@ -1,0 +1,4 @@
+export class SearchAccountBookDto {
+  startDate?: string;
+  endDate?: string;
+}

--- a/src/account-book/dto/search-account-book.dto.ts
+++ b/src/account-book/dto/search-account-book.dto.ts
@@ -1,4 +1,13 @@
+import { Matches } from 'class-validator';
+
 export class SearchAccountBookDto {
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/, {
+    message: 'startDate must be in YYYY-MM-DD format',
+  })
   startDate?: string;
+
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/, {
+    message: 'endDate must be in YYYY-MM-DD format',
+  })
   endDate?: string;
 }


### PR DESCRIPTION
- `getAccountBook` 함수는 가계부의 idx 값으로 한 개의 가계부를 조회합니다.
- `search` 함수는 가계부를 검색합니다.
    - 현재는 시작일과 종료일을 입력, 가계부의 작성일으로 검색할 수 있습니다.